### PR TITLE
Add show reference action for extensions to use

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "activationEvents": [
     "onCommand:references-view.find",
+    "onCommand:references-view.action.showReferences",
     "onView:references-view.tree"
   ],
   "main": "./out/src/extension",

--- a/src/model.ts
+++ b/src/model.ts
@@ -45,6 +45,10 @@ export class Model {
         if (!locations) {
             return undefined;
         }
+        return Model.createWithLocations(uri, position, locations);
+    }
+
+    static async createWithLocations(uri: vscode.Uri, position: vscode.Position, locations: vscode.Location[]): Promise<Model> {
         return new Model(uri, position, locations);
     }
 


### PR DESCRIPTION
For https://github.com/Microsoft/vscode/issues/64376

Adds the equivalent of the `editor.action.showReferences` command for displaying a list of already computed locations in the references view. The JS/TS code lenses can use this command in place of the references peek view 