### PR TITLE
Fixes call hierarchy shows wrong result at first

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -345,7 +345,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('references-view.find', () => findReferencesCommand(ItemSource.References)),
         vscode.commands.registerCommand('references-view.findImplementations', () => findReferencesCommand(ItemSource.Implementations)),
         vscode.commands.registerCommand('references-view.refindReference', findReferencesCommand),
-        vscode.commands.registerCommand('references-view.showCallHierarchy', updateCallHierachyModel),
+        vscode.commands.registerCommand('references-view.showCallHierarchy', () => updateCallHierachyModel()),
         vscode.commands.registerCommand('references-view.showOutgoingCalls', (arg) => setCallHierarchyDirectionCommand(CallsDirection.Outgoing, arg)),
         vscode.commands.registerCommand('references-view.showIncomingCalls', (arg) => setCallHierarchyDirectionCommand(CallsDirection.Incoming, arg)),
         vscode.commands.registerCommand('references-view.refind', refindCommand),

--- a/src/models.ts
+++ b/src/models.ts
@@ -318,7 +318,7 @@ export class RichCallsDirection {
 
     constructor(
         private _mem: vscode.Memento,
-        private _value: CallsDirection = CallsDirection.Incoming,
+        private _value: CallsDirection = CallsDirection.Outgoing,
     ) {
         const raw = _mem.get<number>(RichCallsDirection._key);
         if (typeof raw === 'number' && raw >= 0 && raw <= 1) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/95288

- `updateCallHierachyModel` was being called with an `URI` (equal to activeTextEditor.document.uri) as an argument for the `direction` parameter so I just ignored it
- Also changed the default CallsDirection to `Outgoing` so it matches the vscode default direction for peek Call Hierarchy https://github.com/microsoft/vscode/blob/1c3c0713f080b99977c084ee84631e1deef01383/src/vs/workbench/contrib/callHierarchy/browser/callHierarchy.contribution.ts#L83