### PR TITLE
Extra files shipped

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,3 +5,6 @@ src/
 tsconfig.json
 webpack.config.json
 
+webpack.config.js
+*.d.ts
+media/demo.png

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # References View
 
-This extension shows reference search results as separate view, just like search results. It complements the peek view presentation that is also built into VS Code. The following feature are available: 
+This extension shows reference search results as separate view, just like search results. It complements the peek view presentation that is also built into VS Code. The following feature are available:
 
 * List All References via the Command Palette, the Context Menu, or via <kbd>Alt+Shift+F12</kbd>
 * View references in a dedicated tree view that sits in the sidebar
 * Navigate through search results via <kbd>F4</kbd> and  <kbd>Shift+F4</kbd>
 * Remove references from the list via inline commands
 
-![](media/demo.png)
+![](https://raw.githubusercontent.com/microsoft/vscode-references-view/master/media/demo.png)
 
 **Note** that this extension is bundled with Visual Studio Code version 1.29 and later - it doesn't need to be installed anymore.
 
 ## Requirements
 
-This extension is just an alternative UI for reference search and extensions implementing reference search must still be installed. 
+This extension is just an alternative UI for reference search and extensions implementing reference search must still be installed.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -32,4 +32,3 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-


### PR DESCRIPTION
There's no issue tab, so I'll just put it here:

Inside the vscode folder `%LocalAppData%\Programs\Microsoft VS Code\resources\app\extensions\ms-vscode.references-view` there seems to be some extra files:

- `vscode.d.ts` 340Kb
- `vscode.proposed.d.ts` 50Kb
- `media/demo.png` 900Kb 
- `webpack.config.js`

Image could be replaced with a link `![](https://raw.githubusercontent.com/microsoft/vscode-references-view/master/media/demo.png)`