### PR TITLE
Extend removeRefCommand to support call hierarchy items

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
         {
           "command": "references-view.remove",
           "group": "inline",
-          "when": "view == references-view.tree && viewItem == file-item || view == references-view.tree && viewItem == reference-item"
+          "when": "view == references-view.tree && viewItem == file-item || view == references-view.tree && viewItem == reference-item || view == references-view.tree && viewItem == call-item"
         },
         {
           "command": "references-view.refind",
@@ -203,7 +203,7 @@
         {
           "command": "references-view.remove",
           "group": "1",
-          "when": "view == references-view.tree && viewItem == file-item || view == references-view.tree && viewItem == reference-item"
+          "when": "view == references-view.tree && viewItem == file-item || view == references-view.tree && viewItem == reference-item || view == references-view.tree && viewItem == call-item"
         },
         {
           "command": "references-view.refind",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -227,7 +227,7 @@ export function activate(context: vscode.ExtensionContext) {
         } else if (arg instanceof HistoryItem) {
             uri = arg.uri;
             pos = arg.anchor.getPosition();
-            preserveFocus = false;
+            peserveFocus = false;
         }
 
         if (uri && pos) {
@@ -253,21 +253,22 @@ export function activate(context: vscode.ExtensionContext) {
             if (next) {
                 view.reveal(next, { select: true });
             }
-        }
-        else if (model instanceof CallsModel) {
+        } else if (model instanceof CallsModel) {
             const item = arg as CallItem;
             const next = await model.move(item, true);
             await model.remove(item);
 
-            if (await model.isEmpty())
+            if (await model.isEmpty()) {
                 return clearCommand();
+            }
 
             editorHighlights.refresh();
             showResultsMessage();
-            if (next)
+            if (next) {
                 view.reveal(next, { select: true });
-            else if (item.parent)
-                view.reveal(item.parent, {select: true});
+            } else if (item.parent) {
+                view.reveal(item.parent, { select: true });
+            }
         }
     };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -238,7 +238,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
     };
 
-    const removeRefCommand = async (arg?: ReferenceItem | FileItem | any) => {
+    const removeRefCommand = async (arg?: ReferenceItem | FileItem | CallItem | any) => {
         if (model instanceof ReferencesModel) {
             let next: ReferenceItem | undefined;
             if (arg instanceof ReferenceItem) {
@@ -253,6 +253,21 @@ export function activate(context: vscode.ExtensionContext) {
             if (next) {
                 view.reveal(next, { select: true });
             }
+        }
+        else if (model instanceof CallsModel) {
+            const item = arg as CallItem;
+            const next = await model.move(item, true);
+            await model.remove(item);
+
+            if (await model.isEmpty())
+                return clearCommand();
+
+            editorHighlights.refresh();
+            showResultsMessage();
+            if (next)
+                view.reveal(next, { select: true });
+            else if (item.parent)
+                view.reveal(item.parent, {select: true});
         }
     };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -227,7 +227,7 @@ export function activate(context: vscode.ExtensionContext) {
         } else if (arg instanceof HistoryItem) {
             uri = arg.uri;
             pos = arg.anchor.getPosition();
-            peserveFocus = false;
+            preserveFocus = false;
         }
 
         if (uri && pos) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -360,7 +360,7 @@ export class CallsModel {
 
     readonly roots: Promise<CallItem[]>;
 
-    private readonly _onDidChange = new vscode.EventEmitter<CallsModel | CallItem>();
+    private readonly _onDidChange = new vscode.EventEmitter<CallsModel>();
     readonly onDidChange = this._onDidChange.event;
 
     constructor(readonly uri: vscode.Uri, readonly position: vscode.Position, readonly direction: CallsDirection) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -345,8 +345,8 @@ export class RichCallsDirection {
 }
 
 export class CallItem {
-    children: CallItem[] | undefined = undefined
-    
+    children: CallItem[] | undefined;
+
     constructor(
         readonly item: vscode.CallHierarchyItem,
         readonly parent: CallItem | undefined,
@@ -379,6 +379,13 @@ export class CallsModel {
         }
     }
 
+    async getCallChildren(call: CallItem): Promise<CallItem[]> {
+        if (call.children)
+            return call.children;
+        call.children = await this.resolveCalls(call);
+        return call.children;
+    }
+
     changeDirection(): CallsModel {
         return new CallsModel(this.uri, this.position, this.direction === CallsDirection.Incoming ? CallsDirection.Outgoing : CallsDirection.Incoming);
     }
@@ -396,10 +403,10 @@ export class CallsModel {
         const roots = await this.roots;
         const array = -1 !== roots.indexOf(item) ? roots : item.parent?.children;
 
-        if(!array?.length)
+        if (!array?.length)
             return undefined;
 
-        const ix0 = array.indexOf(item)
+        const ix0 = array.indexOf(item);
         if (1 == array.length && 0 == ix0)
             return undefined; // No siblings to move to.
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -369,7 +369,7 @@ export class CallsModel {
         });
     }
 
-    async resolveCalls(call: CallItem): Promise<CallItem[]> {
+    private async _resolveCalls(call: CallItem): Promise<CallItem[]> {
         if (this.direction === CallsDirection.Incoming) {
             const calls = await vscode.commands.executeCommand<vscode.CallHierarchyIncomingCall[]>('vscode.provideIncomingCalls', call.item);
             return calls ? calls.map(item => new CallItem(item.from, call, item.fromRanges.map(range => new vscode.Location(item.from.uri, range)))) : [];
@@ -383,7 +383,7 @@ export class CallsModel {
         if (call.children) {
             return call.children;
         }
-        call.children = await this.resolveCalls(call);
+        call.children = await this._resolveCalls(call);
         return call.children;
     }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -416,16 +416,11 @@ export class CallsModel {
     }
 
     async remove(item: CallItem): Promise<void> {
-        const roots = await this.roots;
-        if (-1 !== roots.indexOf(item)) {
-            del(roots, item);
-            this._onDidChange.fire(this);
+        const isInRoot = -1 != (await this.roots).indexOf (item)
+        const siblings = isInRoot ? await this.roots : item.parent?.children;
+        if (!siblings)
             return;
-        }
-
-        if (!item.parent?.children)
-            return;
-        del(item.parent.children, item);
+        del(siblings, item);
         this._onDidChange.fire(this);
     }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -380,8 +380,9 @@ export class CallsModel {
     }
 
     async getCallChildren(call: CallItem): Promise<CallItem[]> {
-        if (call.children)
+        if (call.children) {
             return call.children;
+        }
         call.children = await this.resolveCalls(call);
         return call.children;
     }
@@ -403,23 +404,21 @@ export class CallsModel {
         const roots = await this.roots;
         const array = -1 !== roots.indexOf(item) ? roots : item.parent?.children;
 
-        if (!array?.length)
+        if (!array?.length) {
             return undefined;
-
+        }
         const ix0 = array.indexOf(item);
-        if (1 == array.length && 0 == ix0)
+        if (1 == array.length && 0 == ix0) {
             return undefined; // No siblings to move to.
-
-        const delta = fwd ? +1 : -1;
-        const ix = (ix0 + delta + array.length) % array.length;
-        return array[ix];
+        }
     }
 
     async remove(item: CallItem): Promise<void> {
-        const isInRoot = -1 != (await this.roots).indexOf (item)
+        const isInRoot = -1 != (await this.roots).indexOf(item);
         const siblings = isInRoot ? await this.roots : item.parent?.children;
-        if (!siblings)
+        if (!siblings) {
             return;
+        }
         del(siblings, item);
         this._onDidChange.fire(this);
     }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -79,7 +79,7 @@ export class CallItemDataProvider implements vscode.TreeDataProvider<CallHierarc
 
     constructor(
         private _model: CallsModel
-    ) { 
+    ) {
         this._modelListener = _model.onDidChange(e => this._emitter.fire(e instanceof CallHierarchyItem ? e : undefined));
     }
 
@@ -100,20 +100,9 @@ export class CallItemDataProvider implements vscode.TreeDataProvider<CallHierarc
     }
 
     getChildren(element?: CallHierarchyItem | undefined) {
-        if (!element) {
-            return this._model.roots;
-        } else {
-            return element.children
-                ? Promise.resolve(element.children)
-                : this._model.resolveCalls(element).then((value) => {
-                    element.children = value;
-                    return value;
-                });
-        }
-    }
-
-    getParent(element: CallHierarchyItem) {
-        return element.parent;
+        return element
+            ? this._model.getCallChildren(element)
+            : this._model.roots;
     }
 
     // vscode.SymbolKind.File === 0, Module === 1, etc...

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -105,6 +105,10 @@ export class CallItemDataProvider implements vscode.TreeDataProvider<CallHierarc
             : this._model.roots;
     }
 
+    getParent(element: CallHierarchyItem) {
+        return element ? element.parent : undefined;
+    }
+
     // vscode.SymbolKind.File === 0, Module === 1, etc...
     private static _themeIconIds = [
         'symbol-file', 'symbol-module', 'symbol-namespace', 'symbol-package', 'symbol-class', 'symbol-method',

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -106,7 +106,7 @@ export class CallItemDataProvider implements vscode.TreeDataProvider<CallHierarc
     }
 
     getParent(element: CallHierarchyItem) {
-        return element ? element.parent : undefined;
+        return element.parent;
     }
 
     // vscode.SymbolKind.File === 0, Module === 1, etc...


### PR DESCRIPTION
This PR is following [this][issue] issue on VS Code repo. In short, it was asked to also enable the "remove" button for call hierarchy trees to help users cancel out any items they've reviewed.

The problem with adding this feature was that the implementation of the call hierarchy tree, would resolve outgoing/incoming calls on demand (i.e., when the user clicked to expand a node) and then the children data were not taken hold of in the models.

To fulfill the request, a `children` property was added to the `CallItem` model, and `move`, `remove` and change events were added to the `CallsModel` class. The original `removeRefCommand` of the extension was updated accordingly.

:warning: To avoid duplicating private method `ReferencesModel._del`, it's been moved to the outer context and referenced from within`CallsModel`, too. Also, to be consistent, `ReferencesModel._tail` was moved with the former.

[issue]: https://github.com/microsoft/vscode/issues/98155