### PR TITLE
fix microsoft/vscode#117095 de-duplicate reference results.

### DIFF
--- a/src/references/model.ts
+++ b/src/references/model.ts
@@ -70,7 +70,13 @@ export class ReferencesModel implements SymbolItemNavigation<FileItem | Referenc
 				last = new FileItem(loc.uri.with({ fragment: '' }), [], this);
 				this.items.push(last);
 			}
-			last.references.push(new ReferenceItem(loc, last));
+
+			const lastReferenceInFile: ReferenceItem|undefined = last.references[last.references.length - 1];
+			// Because the locations are sorted first, we can check if there is a duplicate reference by simply comparing 
+			// the current item to the last reference pushed to the `FileItem`.
+			if (!lastReferenceInFile || ReferencesModel._compareLocations(item, lastReferenceInFile.location) !== 0) {
+				last.references.push(new ReferenceItem(loc, last));
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit de-duplicates reference location results in the same way that the built-in
'go to references'/peek references behavior does.

The built-in "go to references" command in vscode uses the `ReferencesModel`
to de-duplicate reference results: https://github.com/microsoft/vscode/blob/36dd567011eda09317a76d5dcb820fa9961eb786/src/vs/editor/contrib/gotoSymbol/referencesModel.ts#L171-L182
Equal uri's and ranges constitute duplicate results:
https://github.com/microsoft/vscode/blob/36dd567011eda09317a76d5dcb820fa9961eb786/src/vs/editor/contrib/gotoSymbol/referencesModel.ts#L293-L295

fix microsoft/vscode#117095