### PR TITLE
🔨 Add tooltip to tree items (for calls)

### DIFF
--- a/src/calls/model.ts
+++ b/src/calls/model.ts
@@ -178,7 +178,7 @@ class CallItemDataProvider implements vscode.TreeDataProvider<CallItem> {
 
 		const item = new vscode.TreeItem(element.item.name);
 		item.description = element.item.detail;
-		item.tooltip = item.label? `${item.label} - ${element.item.detail}` : element.item.detail;
+		item.tooltip = item.label ? `${item.label} - ${element.item.detail}` : element.item.detail;
 		item.contextValue = 'call-item';
 		item.iconPath = getThemeIcon(element.item.kind);
 		item.command = {

--- a/src/calls/model.ts
+++ b/src/calls/model.ts
@@ -178,6 +178,7 @@ class CallItemDataProvider implements vscode.TreeDataProvider<CallItem> {
 
 		const item = new vscode.TreeItem(element.item.name);
 		item.description = element.item.detail;
+		item.tooltip = element.item.detail;
 		item.contextValue = 'call-item';
 		item.iconPath = getThemeIcon(element.item.kind);
 		item.command = {

--- a/src/calls/model.ts
+++ b/src/calls/model.ts
@@ -178,7 +178,7 @@ class CallItemDataProvider implements vscode.TreeDataProvider<CallItem> {
 
 		const item = new vscode.TreeItem(element.item.name);
 		item.description = element.item.detail;
-		item.tooltip = element.item.detail;
+		item.tooltip = item.label? `${item.label} - ${element.item.detail}` : element.item.detail;
 		item.contextValue = 'call-item';
 		item.iconPath = getThemeIcon(element.item.kind);
 		item.command = {


### PR DESCRIPTION
Closes microsoft/vscode#146085

Now the tooltip for call items is like this:

![screenshot](https://user-images.githubusercontent.com/36728931/161396209-f9ea408d-d93f-4189-9b73-52c56c47864a.jpeg)