### PR TITLE
Add `getInput()` to API

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,5 +22,9 @@ export function activate(context: vscode.ExtensionContext): SymbolTree {
 		tree.setInput(input);
 	}
 
-	return { setInput };
+	function getInput(): SymbolTreeInput<unknown> | undefined {
+		return tree.getInput();
+	}
+
+	return { setInput, getInput };
 }

--- a/src/references-view.d.ts
+++ b/src/references-view.d.ts
@@ -6,9 +6,10 @@
 import * as vscode from 'vscode';
 
 /**
- * This interface describes the shape for the references viewlet API. It consists 
- * of a single `setInput` function which must be called with a full implementation 
- * of the `SymbolTreeInput`-interface. To acquire this API use the default mechanics, e.g:
+ * This interface describes the shape for the references viewlet API. It includes 
+ * a single `setInput` function which must be called with a full implementation 
+ * of the `SymbolTreeInput`-interface. You can also use `getInput` function to 
+ * get the current `SymbolTreeInput`. To acquire this API use the default mechanics, e.g:
  * 
  * ```ts
  * // get references viewlet API
@@ -16,7 +17,8 @@ import * as vscode from 'vscode';
  * 
  * // instantiate and set input which updates the view
  * const myInput: SymbolTreeInput<MyItems> = ...
- * api.setInput(myInput)
+ * api.setInput(myInput);
+ * const currentInput = api.getInput();
  * ```
  */
 export interface SymbolTree {
@@ -27,6 +29,13 @@ export interface SymbolTree {
 	 * @param input A symbol tree input object
 	 */
 	setInput(input: SymbolTreeInput<unknown>): void;
+
+	/**
+	 * Get the contents of the references viewlet. 
+	 * 
+	 * @returns The current symbol tree input object
+	 */
+	getInput(): SymbolTreeInput<unknown> | undefined;
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: CsCherrYY <chenshi@microsoft.com>

original issue: https://github.com/microsoft/vscode/issues/146037

With this change, we can have a way to get the current valid anchor of the reference-view, it helps to switch to our custom reference views from the preset reference views (supertype view and subtype view).

The usage can be found here: https://github.com/CsCherrYY/vscode-java/blob/bff041f997a6de0cbba9df243c1b7dc3a6f84006/src/typeHierarchy/typeHierarchyTree.ts#L76-L83

Simple demo: 
![getinput](https://user-images.githubusercontent.com/45906942/163794972-018a29b8-f1a5-4cd9-bab0-a4031c935b57.gif)
 