### PR TITLE
Accept `vscode.Location` as an argument for type view

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,13 +19,15 @@ export function register(tree: SymbolsTree, context: vscode.ExtensionContext): v
 		}
 	};
 
-	function setTypeHierarchyDirection(value: TypeHierarchyDirection, anchor: TypeItem | unknown) {
+	function setTypeHierarchyDirection(value: TypeHierarchyDirection, anchor: TypeItem | vscode.Location | unknown) {
 		direction.value = value;
 
 		let newInput: TypesTreeInput | undefined;
 		const oldInput = tree.getInput();
 		if (anchor instanceof TypeItem) {
 			newInput = new TypesTreeInput(new vscode.Location(anchor.item.uri, anchor.item.selectionRange.start), direction.value);
+		} else if (anchor instanceof vscode.Location) {
+			newInput = new TypesTreeInput(anchor, direction.value);
 		} else if (oldInput instanceof TypesTreeInput) {
 			newInput = new TypesTreeInput(oldInput.location, direction.value);
 		}
@@ -36,8 +38,8 @@ export function register(tree: SymbolsTree, context: vscode.ExtensionContext): v
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand('references-view.showTypeHierarchy', showTypeHierarchy),
-		vscode.commands.registerCommand('references-view.showSupertypes', (item: TypeItem | unknown) => setTypeHierarchyDirection(TypeHierarchyDirection.Supertypes, item)),
-		vscode.commands.registerCommand('references-view.showSubtypes', (item: TypeItem | unknown) => setTypeHierarchyDirection(TypeHierarchyDirection.Subtypes, item)),
+		vscode.commands.registerCommand('references-view.showSupertypes', (item: TypeItem | vscode.Location | unknown) => setTypeHierarchyDirection(TypeHierarchyDirection.Supertypes, item)),
+		vscode.commands.registerCommand('references-view.showSubtypes', (item: TypeItem | vscode.Location | unknown) => setTypeHierarchyDirection(TypeHierarchyDirection.Subtypes, item)),
 		vscode.commands.registerCommand('references-view.removeTypeItem', removeTypeItem)
 	);
 }


### PR DESCRIPTION
Signed-off-by: CsCherrYY <chenshi@microsoft.com>

original issue: https://github.com/microsoft/vscode/issues/146037

With this change, we can pass an anchor (`vscode.Location` exactly) to the current `setTypeHierarchyDirection()` to manipulate the preset type views (supertype view and subtype view).

The usage can be found here: https://github.com/CsCherrYY/vscode-java/blob/bff041f997a6de0cbba9df243c1b7dc3a6f84006/src/standardLanguageClient.ts#L421-L427

Simple demo: 
![location](https://user-images.githubusercontent.com/45906942/163795448-0ea13259-f108-401f-9718-c5aa4dda7887.gif)
